### PR TITLE
fix(#4543): ensure BeginRo is followed by tx.Rollback()

### DIFF
--- a/cmd/rpctest/rpctest/account_range_verify.go
+++ b/cmd/rpctest/rpctest/account_range_verify.go
@@ -116,11 +116,22 @@ func CompareAccountRange(logger log.Logger, erigonURL, gethURL, tmpDataDir, geth
 	}
 
 	tgTx, err := resultsKV.BeginRo(context.Background())
+	defer func() {
+		if tgTx != nil {
+			tgTx.Rollback()
+		}
+	}()
 	if err != nil {
 		log.Error(err.Error())
 		return
 	}
+
 	gethTx, err := gethKV.BeginRo(context.Background())
+	defer func() {
+		if gethTx != nil {
+			gethTx.Rollback()
+		}
+	}()
 	if err != nil {
 		log.Error(err.Error())
 		return

--- a/cmd/sentry/sentry/sentry_multi_client.go
+++ b/cmd/sentry/sentry/sentry_multi_client.go
@@ -398,10 +398,10 @@ func (cs *MultiClient) blockHeaders(ctx context.Context, pkt eth.BlockHeadersPac
 	if cs.Hd.POSSync() {
 		sort.Sort(headerdownload.HeadersReverseSort(csHeaders)) // Sorting by reverse order of block heights
 		tx, err := cs.db.BeginRo(ctx)
-		defer tx.Rollback()
 		if err != nil {
 			return err
 		}
+		defer tx.Rollback()
 		penalties, err := cs.Hd.ProcessHeadersPOS(csHeaders, tx, ConvertH512ToPeerID(peerID))
 		if err != nil {
 			return err

--- a/cmd/state/commands/state_root.go
+++ b/cmd/state/commands/state_root.go
@@ -124,6 +124,7 @@ func StateRoot(genesis *core.Genesis, logger log.Logger, blockNum uint64, datadi
 		if tx, err = db.BeginRo(ctx); err != nil {
 			return err
 		}
+		defer tx.Rollback()
 		if rwTx, err = db.BeginRw(ctx); err != nil {
 			return err
 		}

--- a/rules.go
+++ b/rules.go
@@ -33,6 +33,8 @@ func txDeferRollback(m dsl.Matcher) {
 		`$tx, $err = $db.BeginRw($ctx); $chk; $rollback`,
 		`$tx, $err := $db.Begin($ctx); $chk; $rollback`,
 		`$tx, $err = $db.Begin($ctx); $chk; $rollback`,
+		`$tx, $err = $db.BeginRo($ctx); $chk; $rollback`,
+		`$tx, $err := $db.BeginRo($ctx); $chk; $rollback`,
 	).
 		Where(!m["rollback"].Text.Matches(`defer .*\.Rollback()`)).
 		//At(m["rollback"]).


### PR DESCRIPTION
Add missing calls to defer tx rollback. Also adds rules to find BeginRo call with missing defer rollback on the tx.